### PR TITLE
Make settings hashable

### DIFF
--- a/fah_alchemy/settings.py
+++ b/fah_alchemy/settings.py
@@ -19,8 +19,8 @@ class Settings(BaseSettings):
     JWT_EXPIRE_SECONDS: int = 1800
     JWT_ALGORITHM: str = 'HS256'
 
-    def __hash__(self):
-        return hash(tuple(self.dict().items()))
+    class Config:
+        frozen = True
 
 
 @lru_cache()

--- a/fah_alchemy/settings.py
+++ b/fah_alchemy/settings.py
@@ -19,6 +19,9 @@ class Settings(BaseSettings):
     JWT_EXPIRE_SECONDS: int = 1800
     JWT_ALGORITHM: str = 'HS256'
 
+    def __hash__(self):
+        return hash(tuple(self.dict().items()))
+
 
 @lru_cache()
 def get_settings():


### PR DESCRIPTION
Looks like they're not hashable by default? I'm getting complaints from `lru_cache`