### PR TITLE
Add API connectivity check method to `FahAlchemyClientBase`

### DIFF
--- a/fah_alchemy/base/api.py
+++ b/fah_alchemy/base/api.py
@@ -160,7 +160,8 @@ def _check_store_connectivity(n4js: Neo4jStore, s3os: S3ObjectStore) -> dict:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=detail
         )
-    return status.HTTP_200_OK
+    else:
+        return status.HTTP_200_OK
 
 
 async def get_token_data_depends(

--- a/fah_alchemy/base/api.py
+++ b/fah_alchemy/base/api.py
@@ -147,8 +147,9 @@ def scope_params(org: str = None, campaign: str = None, project: str = None):
             headers={"WWW-Authenticate": "Bearer"},
         )
 
+
 def _check_store_connectivity(n4js: Neo4jStore, s3os: S3ObjectStore) -> dict:
-    """ Check if neo4j and s3 object store are reachable """
+    """Check if neo4j and s3 object store are reachable"""
     # check if neo4j database is reachable
     neo4jreachable = n4js._store_check()
     # check if s3 object store is reachable
@@ -156,8 +157,11 @@ def _check_store_connectivity(n4js: Neo4jStore, s3os: S3ObjectStore) -> dict:
 
     if not neo4jreachable or not s3reachable:
         detail = f"Attempt to reach services failed, Neo4j reachable: {neo4jreachable}, S3 reachable: {s3reachable}"
-        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=detail)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=detail
+        )
     return status.HTTP_200_OK
+
 
 async def get_token_data_depends(
     token: str = Depends(oauth2_scheme),

--- a/fah_alchemy/base/api.py
+++ b/fah_alchemy/base/api.py
@@ -147,6 +147,21 @@ def scope_params(org: str = None, campaign: str = None, project: str = None):
             headers={"WWW-Authenticate": "Bearer"},
         )
 
+def _check_store_connectivity(n4js: Neo4jStore, s3os: S3ObjectStore) -> dict:
+    """ Check if neo4j and s3 object store are reachable """
+    # check if neo4j database is reachable
+    neo4jreachable = n4js._store_check()
+
+    # check if s3 object store is reachable
+    s3reachable = s3os._store_check()
+
+    if not neo4jreachable or not s3reachable:
+        code = status.HTTP_503_SERVICE_UNAVAILABLE
+        detail = f"Attempt to reach services failed, Neo4j: {neo4jreachable}, S3 reachable: {s3reachable}"
+        raise HTTPException(status_code=code, detail=detail)
+    else:
+        code = status.HTTP_200_OK 
+    return code
 
 async def get_token_data_depends(
     token: str = Depends(oauth2_scheme),

--- a/fah_alchemy/base/api.py
+++ b/fah_alchemy/base/api.py
@@ -161,7 +161,7 @@ def _check_store_connectivity(n4js: Neo4jStore, s3os: S3ObjectStore) -> dict:
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=detail
         )
     else:
-        return status.HTTP_200_OK
+        return True
 
 
 async def get_token_data_depends(

--- a/fah_alchemy/base/api.py
+++ b/fah_alchemy/base/api.py
@@ -151,17 +151,13 @@ def _check_store_connectivity(n4js: Neo4jStore, s3os: S3ObjectStore) -> dict:
     """ Check if neo4j and s3 object store are reachable """
     # check if neo4j database is reachable
     neo4jreachable = n4js._store_check()
-
     # check if s3 object store is reachable
     s3reachable = s3os._store_check()
 
     if not neo4jreachable or not s3reachable:
-        code = status.HTTP_503_SERVICE_UNAVAILABLE
-        detail = f"Attempt to reach services failed, Neo4j: {neo4jreachable}, S3 reachable: {s3reachable}"
-        raise HTTPException(status_code=code, detail=detail)
-    else:
-        code = status.HTTP_200_OK 
-    return code
+        detail = f"Attempt to reach services failed, Neo4j reachable: {neo4jreachable}, S3 reachable: {s3reachable}"
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=detail)
+    return status.HTTP_200_OK
 
 async def get_token_data_depends(
     token: str = Depends(oauth2_scheme),

--- a/fah_alchemy/base/client.py
+++ b/fah_alchemy/base/client.py
@@ -96,7 +96,9 @@ class FahAlchemyBaseClient:
         resp = requests.get(url, params=params, headers=self._headers)
 
         if not 200 <= resp.status_code < 300:
-            raise self._exception(f"Status Code {resp.status_code} : {resp.reason} : Details {resp.json()['detail']}")
+            raise self._exception(
+                f"Status Code {resp.status_code} : {resp.reason} : Details {resp.json()['detail']}"
+            )
         content = json.loads(resp.text, cls=JSON_HANDLER.decoder)
 
         if return_gufe:

--- a/fah_alchemy/base/client.py
+++ b/fah_alchemy/base/client.py
@@ -124,18 +124,4 @@ class FahAlchemyBaseClient:
     @_use_token
     def _api_check(self):
         # Check if the API is up and running and can reach services
-        url = urljoin(self.api_url, "/check")
-        resp = requests.get(url, headers=self._headers)
-
-        if not 200 <= resp.status_code < 300:
-            # can't contact the endpoints
-            raise self._exception(f"Status Code {resp.status_code} : {resp.reason}")
-
-        details = resp.json()
-        if details["code"] != status.HTTP_200_OK:
-
-            # endpoints cannot connect to services
-            error = f"Attempt to reach services failed, Neo4j: {details['neo4jreachable']}, S3 reachable: {details['s3reachable']}"
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=error
-            )
+        self._get_resource("/check", params={}, return_gufe=False)

--- a/fah_alchemy/base/client.py
+++ b/fah_alchemy/base/client.py
@@ -127,3 +127,7 @@ class FahAlchemyBaseClient:
         resp = requests.get(url, headers=self._headers)
         if resp.status_code != 200:
             raise self._exception(f"Status Code {resp.status_code} : {resp.reason}, detail: {resp.text}")
+        details = resp.json()
+        if details["code"] != status.HTTP_200_OK:
+            error = f"Attempt to reach services failed, Neo4j: {details['neo4jreachable']}, S3 reachable: {details['s3reachable']}"
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=error)

--- a/fah_alchemy/base/client.py
+++ b/fah_alchemy/base/client.py
@@ -126,4 +126,4 @@ class FahAlchemyBaseClient:
         url = urljoin(self.api_url, "/check")
         resp = requests.get(url, headers=self._headers)
         if resp.status_code != 200:
-            raise self._exception(f"Status Code {resp.status_code} : {resp.reason}")
+            raise self._exception(f"Status Code {resp.status_code} : {resp.reason}, detail: {resp.text}")

--- a/fah_alchemy/base/client.py
+++ b/fah_alchemy/base/client.py
@@ -122,7 +122,7 @@ class FahAlchemyBaseClient:
     
     @_use_token
     def _api_check(self):
-        # Check if the API is up and running and can return a 200 OK code
+        # Check if the API is up and running and can reach services
         url = urljoin(self.api_url, "/check")
         resp = requests.get(url, headers=self._headers)
         if resp.status_code != 200:

--- a/fah_alchemy/base/client.py
+++ b/fah_alchemy/base/client.py
@@ -126,11 +126,14 @@ class FahAlchemyBaseClient:
         # Check if the API is up and running and can reach services
         url = urljoin(self.api_url, "/check")
         resp = requests.get(url, headers=self._headers)
+
         if not 200 <= resp.status_code < 300:
             # can't contact the endpoints
             raise self._exception(f"Status Code {resp.status_code} : {resp.reason}")
+
         details = resp.json()
         if details["code"] != status.HTTP_200_OK:
+
             # endpoints cannot connect to services
             error = f"Attempt to reach services failed, Neo4j: {details['neo4jreachable']}, S3 reachable: {details['s3reachable']}"
             raise HTTPException(

--- a/fah_alchemy/base/client.py
+++ b/fah_alchemy/base/client.py
@@ -126,8 +126,12 @@ class FahAlchemyBaseClient:
         # Check if the API is up and running and can reach services
         url = urljoin(self.api_url, "/check")
         resp = requests.get(url, headers=self._headers)
+        if not 200 <= resp.status_code < 300:
+            # can't contact the endpoints
+            raise self._exception(f"Status Code {resp.status_code} : {resp.reason}")
         details = resp.json()
         if details["code"] != status.HTTP_200_OK:
+            # endpoints cannot connect to services
             error = f"Attempt to reach services failed, Neo4j: {details['neo4jreachable']}, S3 reachable: {details['s3reachable']}"
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=error

--- a/fah_alchemy/base/client.py
+++ b/fah_alchemy/base/client.py
@@ -6,7 +6,6 @@ from typing import List
 import json
 from urllib.parse import urljoin
 from functools import wraps
-from fastapi import status, HTTPException
 
 import requests
 from requests.auth import HTTPBasicAuth
@@ -97,8 +96,7 @@ class FahAlchemyBaseClient:
         resp = requests.get(url, params=params, headers=self._headers)
 
         if not 200 <= resp.status_code < 300:
-            raise self._exception(f"Status Code {resp.status_code} : {resp.reason}")
-
+            raise self._exception(f"Status Code {resp.status_code} : {resp.reason} : Details {resp.json()['detail']}")
         content = json.loads(resp.text, cls=JSON_HANDLER.decoder)
 
         if return_gufe:

--- a/fah_alchemy/base/client.py
+++ b/fah_alchemy/base/client.py
@@ -119,3 +119,11 @@ class FahAlchemyBaseClient:
 
     def get_info(self):
         return self._get_resource("/info", params={}, return_gufe=False)
+    
+    @_use_token
+    def _api_check(self):
+        # Check if the API is up and running and can return a 200 OK code
+        url = urljoin(self.api_url, "/check")
+        resp = requests.get(url, headers=self._headers)
+        if resp.status_code != 200:
+            raise self._exception(f"Status Code {resp.status_code} : {resp.reason}")

--- a/fah_alchemy/base/client.py
+++ b/fah_alchemy/base/client.py
@@ -6,6 +6,7 @@ from typing import List
 import json
 from urllib.parse import urljoin
 from functools import wraps
+from fastapi import status
 
 import requests
 from requests.auth import HTTPBasicAuth
@@ -119,15 +120,15 @@ class FahAlchemyBaseClient:
 
     def get_info(self):
         return self._get_resource("/info", params={}, return_gufe=False)
-    
+
     @_use_token
     def _api_check(self):
         # Check if the API is up and running and can reach services
         url = urljoin(self.api_url, "/check")
         resp = requests.get(url, headers=self._headers)
-        if resp.status_code != 200:
-            raise self._exception(f"Status Code {resp.status_code} : {resp.reason}, detail: {resp.text}")
         details = resp.json()
         if details["code"] != status.HTTP_200_OK:
             error = f"Attempt to reach services failed, Neo4j: {details['neo4jreachable']}, S3 reachable: {details['s3reachable']}"
-            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=error)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=error
+            )

--- a/fah_alchemy/base/client.py
+++ b/fah_alchemy/base/client.py
@@ -6,7 +6,7 @@ from typing import List
 import json
 from urllib.parse import urljoin
 from functools import wraps
-from fastapi import status
+from fastapi import status, HTTPException
 
 import requests
 from requests.auth import HTTPBasicAuth

--- a/fah_alchemy/compute/api.py
+++ b/fah_alchemy/compute/api.py
@@ -62,6 +62,7 @@ async def ping():
 async def info():
     return {"message": "nothing yet"}
 
+
 @router.get("/check")
 async def check(
     n4js: Neo4jStore = Depends(get_n4js_depends),
@@ -75,7 +76,8 @@ async def check(
         code = status.HTTP_503_SERVICE_UNAVAILABLE
     else:
         code = status.HTTP_200_OK
-    return  {'neo4jreachable': neo4jreachable, 's3reachable': s3reachable, 'code': code}
+    return {"neo4jreachable": neo4jreachable, "s3reachable": s3reachable, "code": code}
+
 
 @router.get("/taskqueues")
 async def query_taskqueues(

--- a/fah_alchemy/compute/api.py
+++ b/fah_alchemy/compute/api.py
@@ -62,6 +62,9 @@ async def ping():
 async def info():
     return {"message": "nothing yet"}
 
+@router.get("/check")
+async def check():
+    return 200
 
 @router.get("/taskqueues")
 async def query_taskqueues(

--- a/fah_alchemy/compute/api.py
+++ b/fah_alchemy/compute/api.py
@@ -71,10 +71,14 @@ async def check(
     neo4jreachable = n4js._store_check()
     # check if s3 object store is reachable
     s3reachable = s3os._store_check()
-    if not neo4jreachable or not s3reachable:
-        return 503
+    if (not neo4jreachable) and (not s3reachable):
+        return 'Neo4j store and S3 store unreachable', 503
+    elif not neo4jreachable:
+        return 'Neo4j store unreachable', 503
+    elif not s3reachable:
+        return 'S3 store unreachable', 503
     else:
-        return 200
+        return '', 200
 
 @router.get("/taskqueues")
 async def query_taskqueues(

--- a/fah_alchemy/compute/api.py
+++ b/fah_alchemy/compute/api.py
@@ -70,7 +70,8 @@ async def check(
     s3os: S3ObjectStore = Depends(get_s3os_depends),
 ):
     # check connectivity of storage components
-    return _check_store_connectivity(n4js, s3os)
+    # if no exception raised, all good
+    _check_store_connectivity(n4js, s3os)
 
 
 @router.get("/taskqueues")

--- a/fah_alchemy/compute/api.py
+++ b/fah_alchemy/compute/api.py
@@ -71,14 +71,11 @@ async def check(
     neo4jreachable = n4js._store_check()
     # check if s3 object store is reachable
     s3reachable = s3os._store_check()
-    if (not neo4jreachable) and (not s3reachable):
-        return 'Neo4j store and S3 store unreachable', 503
-    elif not neo4jreachable:
-        return 'Neo4j store unreachable', 503
-    elif not s3reachable:
-        return 'S3 store unreachable', 503
+    if not neo4jreachable or not s3reachable:
+        code = status.HTTP_503_SERVICE_UNAVAILABLE
     else:
-        return '', 200
+        code = status.HTTP_200_OK
+    return  {'neo4jreachable': neo4jreachable, 's3reachable': s3reachable, 'code': code}
 
 @router.get("/taskqueues")
 async def query_taskqueues(

--- a/fah_alchemy/compute/api.py
+++ b/fah_alchemy/compute/api.py
@@ -63,8 +63,18 @@ async def info():
     return {"message": "nothing yet"}
 
 @router.get("/check")
-async def check():
-    return 200
+async def check(
+    n4js: Neo4jStore = Depends(get_n4js_depends),
+    s3os: S3ObjectStore = Depends(get_s3os_depends),
+):
+    # check if neo4j database is reachable
+    neo4jreachable = n4js._store_check()
+    # check if s3 object store is reachable
+    s3reachable = s3os._store_check()
+    if not neo4jreachable or not s3reachable:
+        return 503
+    else:
+        return 200
 
 @router.get("/taskqueues")
 async def query_taskqueues(

--- a/fah_alchemy/compute/api.py
+++ b/fah_alchemy/compute/api.py
@@ -21,6 +21,7 @@ from ..base.api import (
     get_cred_entity,
     validate_scopes,
     validate_scopes_query,
+    _check_store_connectivity,
 )
 from ..settings import get_base_api_settings, get_compute_api_settings
 from ..storage.statestore import Neo4jStore
@@ -68,15 +69,8 @@ async def check(
     n4js: Neo4jStore = Depends(get_n4js_depends),
     s3os: S3ObjectStore = Depends(get_s3os_depends),
 ):
-    # check if neo4j database is reachable
-    neo4jreachable = n4js._store_check()
-    # check if s3 object store is reachable
-    s3reachable = s3os._store_check()
-    if not neo4jreachable or not s3reachable:
-        code = status.HTTP_503_SERVICE_UNAVAILABLE
-    else:
-        code = status.HTTP_200_OK
-    return {"neo4jreachable": neo4jreachable, "s3reachable": s3reachable, "code": code}
+    # check connectivity of storage components
+    return _check_store_connectivity(n4js, s3os)
 
 
 @router.get("/taskqueues")

--- a/fah_alchemy/interface/api.py
+++ b/fah_alchemy/interface/api.py
@@ -67,7 +67,8 @@ async def check(
     s3os: S3ObjectStore = Depends(get_s3os_depends),
 ):
     # check connectivity of storage components
-    return _check_store_connectivity(n4js, s3os)
+    # if no exception raised, all good
+    _check_store_connectivity(n4js, s3os)
 
 
 ### inputs

--- a/fah_alchemy/interface/api.py
+++ b/fah_alchemy/interface/api.py
@@ -23,7 +23,7 @@ from ..base.api import (
     get_cred_entity,
     validate_scopes,
     validate_scopes_query,
-    _check_store_connectivity
+    _check_store_connectivity,
 )
 from ..settings import get_api_settings
 from ..settings import get_base_api_settings, get_api_settings
@@ -68,6 +68,7 @@ async def check(
 ):
     # check connectivity of storage components
     return _check_store_connectivity(n4js, s3os)
+
 
 ### inputs
 

--- a/fah_alchemy/interface/api.py
+++ b/fah_alchemy/interface/api.py
@@ -67,8 +67,10 @@ async def check(
 ):
     # check if neo4j database is reachable
     neo4jreachable = n4js._store_check()
+
     # check if s3 object store is reachable
     s3reachable = s3os._store_check()
+
     if not neo4jreachable or not s3reachable:
         code = status.HTTP_503_SERVICE_UNAVAILABLE
     else:

--- a/fah_alchemy/interface/api.py
+++ b/fah_alchemy/interface/api.py
@@ -60,6 +60,10 @@ async def info():
     return {"message": "nothing yet"}
 
 
+@router.get("/check")
+async def check():
+    return 200
+
 ### inputs
 
 

--- a/fah_alchemy/interface/api.py
+++ b/fah_alchemy/interface/api.py
@@ -69,14 +69,11 @@ async def check(
     neo4jreachable = n4js._store_check()
     # check if s3 object store is reachable
     s3reachable = s3os._store_check()
-    if (not neo4jreachable) and (not s3reachable):
-        return 'Neo4j store and S3 store unreachable', 503
-    elif not neo4jreachable:
-        return 'Neo4j store unreachable', 503
-    elif not s3reachable:
-        return 'S3 store unreachable', 503
+    if not neo4jreachable or not s3reachable:
+        code = status.HTTP_503_SERVICE_UNAVAILABLE
     else:
-        return '', 200
+        code = status.HTTP_200_OK
+    return  {'neo4jreachable': neo4jreachable, 's3reachable': s3reachable, 'code': code}
 
 
 ### inputs

--- a/fah_alchemy/interface/api.py
+++ b/fah_alchemy/interface/api.py
@@ -73,7 +73,7 @@ async def check(
         code = status.HTTP_503_SERVICE_UNAVAILABLE
     else:
         code = status.HTTP_200_OK
-    return  {'neo4jreachable': neo4jreachable, 's3reachable': s3reachable, 'code': code}
+    return {"neo4jreachable": neo4jreachable, "s3reachable": s3reachable, "code": code}
 
 
 ### inputs

--- a/fah_alchemy/interface/api.py
+++ b/fah_alchemy/interface/api.py
@@ -66,13 +66,17 @@ async def check(
     s3os: S3ObjectStore = Depends(get_s3os_depends),
 ):
     # check if neo4j database is reachable
-    neo4jreachable = n4js._api_check()
+    neo4jreachable = n4js._store_check()
     # check if s3 object store is reachable
-    s3reachable = s3os._api_check()
-    if not neo4jreachable or not s3reachable:
-        return 503
+    s3reachable = s3os._store_check()
+    if (not neo4jreachable) and (not s3reachable):
+        return 'Neo4j store and S3 store unreachable', 503
+    elif not neo4jreachable:
+        return 'Neo4j store unreachable', 503
+    elif not s3reachable:
+        return 'S3 store unreachable', 503
     else:
-        return 200
+        return '', 200
 
 
 ### inputs

--- a/fah_alchemy/interface/api.py
+++ b/fah_alchemy/interface/api.py
@@ -23,6 +23,7 @@ from ..base.api import (
     get_cred_entity,
     validate_scopes,
     validate_scopes_query,
+    _check_store_connectivity
 )
 from ..settings import get_api_settings
 from ..settings import get_base_api_settings, get_api_settings
@@ -65,18 +66,8 @@ async def check(
     n4js: Neo4jStore = Depends(get_n4js_depends),
     s3os: S3ObjectStore = Depends(get_s3os_depends),
 ):
-    # check if neo4j database is reachable
-    neo4jreachable = n4js._store_check()
-
-    # check if s3 object store is reachable
-    s3reachable = s3os._store_check()
-
-    if not neo4jreachable or not s3reachable:
-        code = status.HTTP_503_SERVICE_UNAVAILABLE
-    else:
-        code = status.HTTP_200_OK
-    return {"neo4jreachable": neo4jreachable, "s3reachable": s3reachable, "code": code}
-
+    # check connectivity of storage components
+    return _check_store_connectivity(n4js, s3os)
 
 ### inputs
 

--- a/fah_alchemy/interface/api.py
+++ b/fah_alchemy/interface/api.py
@@ -61,8 +61,19 @@ async def info():
 
 
 @router.get("/check")
-async def check():
-    return 200
+async def check(
+    n4js: Neo4jStore = Depends(get_n4js_depends),
+    s3os: S3ObjectStore = Depends(get_s3os_depends),
+):
+    # check if neo4j database is reachable
+    neo4jreachable = n4js._api_check()
+    # check if s3 object store is reachable
+    s3reachable = s3os._api_check()
+    if not neo4jreachable or not s3reachable:
+        return 503
+    else:
+        return 200
+
 
 ### inputs
 

--- a/fah_alchemy/interface/client.py
+++ b/fah_alchemy/interface/client.py
@@ -61,8 +61,8 @@ class FahAlchemyClient(FahAlchemyBaseClient):
     ### results
 
     def get_transformation_result(
-        self, 
-        transformation: ScopedKey, 
+        self,
+        transformation: ScopedKey,
         return_protocoldagresults: bool = False,
     ) -> Union[ProtocolResult, List[List[ProtocolDAGResult]]]:
         """Get `ProtocolResult` for the given `Transformation`.
@@ -85,7 +85,6 @@ class FahAlchemyClient(FahAlchemyBaseClient):
         tf: Transformation = self.get_transformation(transformation)
 
         while True:
-
             # iterate through all results with paginated API calls
             params = {"limit": limit, "skip": skip}
             pdrs_i = self._get_resource(

--- a/fah_alchemy/storage/objectstore.py
+++ b/fah_alchemy/storage/objectstore.py
@@ -64,8 +64,8 @@ class S3ObjectStore:
             self.resource.meta.client.list_buckets()
 
             # write check
-            self._store_bytes('_check_test', b'test_check')
-            self._delete('_check_test')
+            self._store_bytes("_check_test", b"test_check")
+            self._delete("_check_test")
         except:
             return False
         return True

--- a/fah_alchemy/storage/objectstore.py
+++ b/fah_alchemy/storage/objectstore.py
@@ -60,10 +60,10 @@ class S3ObjectStore:
     def _store_check(self):
         """Check that the ObjectStore is in a state that can be used by the API."""
         try:
-            # just return our identity
-            self.resource.meta.client.get_caller_identity()
+            # just list buckets
+            self.resource.meta.client.list_buckets()
         except:
-            return False            
+            return False
         return True 
 
     def reset(self):

--- a/fah_alchemy/storage/objectstore.py
+++ b/fah_alchemy/storage/objectstore.py
@@ -57,7 +57,7 @@ class S3ObjectStore:
         """Check consistency of object store."""
         raise NotImplementedError
     
-    def _api_check(self):
+    def _store_check(self):
         """Check that the ObjectStore is in a state that can be used by the API."""
         try:
             # just return our identity

--- a/fah_alchemy/storage/objectstore.py
+++ b/fah_alchemy/storage/objectstore.py
@@ -60,8 +60,12 @@ class S3ObjectStore:
     def _store_check(self):
         """Check that the ObjectStore is in a state that can be used by the API."""
         try:
-            # just list buckets
+            # read check
             self.resource.meta.client.list_buckets()
+
+            # write check
+            self._store_bytes('_check_test', b'test_check')
+            self._delete('_check_test')
         except:
             return False
         return True
@@ -148,7 +152,7 @@ class S3ObjectStore:
         key = os.path.join(self.prefix, location)
 
         if self._exists(location):
-            self.resouce.Object(self.bucket, key).delete()
+            self.resource.Object(self.bucket, key).delete()
         else:
             raise S3ObjectStoreError(
                 f"Unable to delete '{str(key)}': Object does not exist"

--- a/fah_alchemy/storage/objectstore.py
+++ b/fah_alchemy/storage/objectstore.py
@@ -56,6 +56,15 @@ class S3ObjectStore:
     def check(self):
         """Check consistency of object store."""
         raise NotImplementedError
+    
+    def _api_check(self):
+        """Check that the ObjectStore is in a state that can be used by the API."""
+        try:
+            # just return our identity
+            self.resource.meta.client.get_caller_identity()
+        except:
+            return False            
+        return True 
 
     def reset(self):
         """Remove all data from object store.

--- a/fah_alchemy/storage/objectstore.py
+++ b/fah_alchemy/storage/objectstore.py
@@ -56,7 +56,7 @@ class S3ObjectStore:
     def check(self):
         """Check consistency of object store."""
         raise NotImplementedError
-    
+
     def _store_check(self):
         """Check that the ObjectStore is in a state that can be used by the API."""
         try:
@@ -64,7 +64,7 @@ class S3ObjectStore:
             self.resource.meta.client.list_buckets()
         except:
             return False
-        return True 
+        return True
 
     def reset(self):
         """Remove all data from object store.

--- a/fah_alchemy/storage/statestore.py
+++ b/fah_alchemy/storage/statestore.py
@@ -132,6 +132,16 @@ class Neo4jStore(FahAlchemyStateStore):
         if nope.identity != 0:
             raise Neo4JStoreError("Identity of NOPE node is not exactly 0")
 
+    def _api_check(self):
+        """Check that the database is in a state that can be used by the API."""
+        try:
+            # just list available functions to see if database is working
+            self.graph.run("SHOW FUNCTIONS YIELD *")
+        except:
+            return False
+
+        return True 
+
     def reset(self):
         """Remove all data from database; undo all components in `initialize`."""
         # we'll keep NOPE around to avoid a case where Neo4j doesn't give it id 0

--- a/fah_alchemy/storage/statestore.py
+++ b/fah_alchemy/storage/statestore.py
@@ -132,7 +132,7 @@ class Neo4jStore(FahAlchemyStateStore):
         if nope.identity != 0:
             raise Neo4JStoreError("Identity of NOPE node is not exactly 0")
 
-    def _api_check(self):
+    def _store_check(self):
         """Check that the database is in a state that can be used by the API."""
         try:
             # just list available functions to see if database is working

--- a/fah_alchemy/storage/statestore.py
+++ b/fah_alchemy/storage/statestore.py
@@ -139,8 +139,7 @@ class Neo4jStore(FahAlchemyStateStore):
             self.graph.run("SHOW FUNCTIONS YIELD *")
         except:
             return False
-
-        return True 
+        return True
 
     def reset(self):
         """Remove all data from database; undo all components in `initialize`."""

--- a/fah_alchemy/tests/integration/compute/client/test_compute_client.py
+++ b/fah_alchemy/tests/integration/compute/client/test_compute_client.py
@@ -68,3 +68,12 @@ class TestComputeClient:
 
         ...
         # task = compute_client.claim_taskqueue_task(scope_test)
+
+
+    def test_api_check(
+        self,
+        n4js_preloaded,
+        user_client: client.FahAlchemyComputeClient,
+        uvicorn_server,
+    ):
+        user_client._api_check()

--- a/fah_alchemy/tests/integration/compute/client/test_compute_client.py
+++ b/fah_alchemy/tests/integration/compute/client/test_compute_client.py
@@ -73,7 +73,7 @@ class TestComputeClient:
     def test_api_check(
         self,
         n4js_preloaded,
-        user_client: client.FahAlchemyComputeClient,
+        compute_client: client.FahAlchemyComputeClient,
         uvicorn_server,
     ):
-        user_client._api_check()
+        compute_client._api_check()

--- a/fah_alchemy/tests/integration/compute/client/test_compute_client.py
+++ b/fah_alchemy/tests/integration/compute/client/test_compute_client.py
@@ -69,7 +69,6 @@ class TestComputeClient:
         ...
         # task = compute_client.claim_taskqueue_task(scope_test)
 
-
     def test_api_check(
         self,
         n4js_preloaded,

--- a/fah_alchemy/tests/integration/compute/test_compute_api.py
+++ b/fah_alchemy/tests/integration/compute/test_compute_api.py
@@ -13,18 +13,16 @@ class TestComputeAPI:
     def test_info(self, test_client):
         response = test_client.get("/info")
         assert response.status_code == 200
-    
+
     def test_check(self, test_client):
         response = test_client.get("/check")
         assert response.status_code == 200
         details = response.json()
-        assert(details["neo4jreachable"])
-        assert(details["s3reachable"])
-        assert(details["code"] == status.HTTP_200_OK)
-
+        assert details["neo4jreachable"]
+        assert details["s3reachable"]
+        assert details["code"] == status.HTTP_200_OK
 
     def test_query_taskqueues(self, n4js_preloaded, test_client):
-
         response = test_client.get("/taskqueues")
         assert response.status_code == 200
 

--- a/fah_alchemy/tests/integration/compute/test_compute_api.py
+++ b/fah_alchemy/tests/integration/compute/test_compute_api.py
@@ -10,8 +10,11 @@ from fah_alchemy.storage.models import ObjectStoreRef
 
 class TestComputeAPI:
     def test_info(self, test_client):
-
         response = test_client.get("/info")
+        assert response.status_code == 200
+    
+    def test_check(self, test_client):
+        response = test_client.get("/check")
         assert response.status_code == 200
 
     def test_query_taskqueues(self, n4js_preloaded, test_client):

--- a/fah_alchemy/tests/integration/compute/test_compute_api.py
+++ b/fah_alchemy/tests/integration/compute/test_compute_api.py
@@ -6,7 +6,6 @@ from gufe.tokenization import GufeTokenizable
 from fah_alchemy.models import ScopedKey
 from fah_alchemy.compute import client
 from fah_alchemy.storage.models import ObjectStoreRef
-from fastapi import status
 
 
 class TestComputeAPI:
@@ -17,10 +16,6 @@ class TestComputeAPI:
     def test_check(self, test_client):
         response = test_client.get("/check")
         assert response.status_code == 200
-        details = response.json()
-        assert details["neo4jreachable"]
-        assert details["s3reachable"]
-        assert details["code"] == status.HTTP_200_OK
 
     def test_query_taskqueues(self, n4js_preloaded, test_client):
         response = test_client.get("/taskqueues")

--- a/fah_alchemy/tests/integration/compute/test_compute_api.py
+++ b/fah_alchemy/tests/integration/compute/test_compute_api.py
@@ -6,6 +6,7 @@ from gufe.tokenization import GufeTokenizable
 from fah_alchemy.models import ScopedKey
 from fah_alchemy.compute import client
 from fah_alchemy.storage.models import ObjectStoreRef
+from fastapi import status
 
 
 class TestComputeAPI:
@@ -16,6 +17,11 @@ class TestComputeAPI:
     def test_check(self, test_client):
         response = test_client.get("/check")
         assert response.status_code == 200
+        details = response.json()
+        assert(details['neo4jreachable'])
+        assert(details['s3reachable'])
+        assert(details['code'] == status.HTTP_200_OK)
+
 
     def test_query_taskqueues(self, n4js_preloaded, test_client):
 

--- a/fah_alchemy/tests/integration/compute/test_compute_api.py
+++ b/fah_alchemy/tests/integration/compute/test_compute_api.py
@@ -18,9 +18,9 @@ class TestComputeAPI:
         response = test_client.get("/check")
         assert response.status_code == 200
         details = response.json()
-        assert(details['neo4jreachable'])
-        assert(details['s3reachable'])
-        assert(details['code'] == status.HTTP_200_OK)
+        assert(details["neo4jreachable"])
+        assert(details["s3reachable"])
+        assert(details["code"] == status.HTTP_200_OK)
 
 
     def test_query_taskqueues(self, n4js_preloaded, test_client):

--- a/fah_alchemy/tests/integration/interface/client/test_client.py
+++ b/fah_alchemy/tests/integration/interface/client/test_client.py
@@ -51,3 +51,10 @@ class TestClient:
         uvicorn_server,
     ):
         ...
+
+    def test_api_check(        self,
+        n4js_preloaded,
+        user_client: client.FahAlchemyClient,
+        uvicorn_server,
+    ):
+        user_client._api_check()

--- a/fah_alchemy/tests/integration/interface/client/test_client.py
+++ b/fah_alchemy/tests/integration/interface/client/test_client.py
@@ -52,7 +52,8 @@ class TestClient:
     ):
         ...
 
-    def test_api_check(        self,
+    def test_api_check(
+        self,
         n4js_preloaded,
         user_client: client.FahAlchemyClient,
         uvicorn_server,

--- a/fah_alchemy/tests/integration/interface/test_api.py
+++ b/fah_alchemy/tests/integration/interface/test_api.py
@@ -1,6 +1,7 @@
 import pytest
 import json
 
+from fastapi import status
 from gufe import AlchemicalNetwork, ChemicalSystem, Transformation
 from gufe.tokenization import JSON_HANDLER, GufeTokenizable
 
@@ -44,6 +45,10 @@ class TestAPI:
     def test_check(self, test_client):
         response = test_client.get("/check")
         assert response.status_code == 200
+        details = response.json()
+        assert(details['neo4jreachable'])
+        assert(details['s3reachable'])
+        assert(details['code'] == status.HTTP_200_OK)
 
     def test_create_network(
         self, n4js_preloaded, test_client, network_tyk2, scope_test

--- a/fah_alchemy/tests/integration/interface/test_api.py
+++ b/fah_alchemy/tests/integration/interface/test_api.py
@@ -5,8 +5,6 @@ from gufe import AlchemicalNetwork, ChemicalSystem, Transformation
 from gufe.tokenization import JSON_HANDLER, GufeTokenizable
 
 from fah_alchemy.models import ScopedKey
-from fastapi import status
-
 
 def pre_load_payload(network, scope, name="incomplete 2"):
     """Helper function to spin up networks for testing"""
@@ -45,10 +43,6 @@ class TestAPI:
     def test_check(self, test_client):
         response = test_client.get("/check")
         assert response.status_code == 200
-        details = response.json()
-        assert details["neo4jreachable"]
-        assert details["s3reachable"]
-        assert details["code"] == status.HTTP_200_OK
 
     def test_create_network(
         self, n4js_preloaded, test_client, network_tyk2, scope_test

--- a/fah_alchemy/tests/integration/interface/test_api.py
+++ b/fah_alchemy/tests/integration/interface/test_api.py
@@ -6,6 +6,7 @@ from gufe.tokenization import JSON_HANDLER, GufeTokenizable
 
 from fah_alchemy.models import ScopedKey
 
+
 def pre_load_payload(network, scope, name="incomplete 2"):
     """Helper function to spin up networks for testing"""
     new_network = AlchemicalNetwork(

--- a/fah_alchemy/tests/integration/interface/test_api.py
+++ b/fah_alchemy/tests/integration/interface/test_api.py
@@ -1,11 +1,11 @@
 import pytest
 import json
 
-from fastapi import status
 from gufe import AlchemicalNetwork, ChemicalSystem, Transformation
 from gufe.tokenization import JSON_HANDLER, GufeTokenizable
 
 from fah_alchemy.models import ScopedKey
+from fastapi import status
 
 
 def pre_load_payload(network, scope, name="incomplete 2"):
@@ -41,14 +41,14 @@ class TestAPI:
     def test_info(self, test_client):
         response = test_client.get("/info")
         assert response.status_code == 200
-    
+
     def test_check(self, test_client):
         response = test_client.get("/check")
         assert response.status_code == 200
         details = response.json()
-        assert(details['neo4jreachable'])
-        assert(details['s3reachable'])
-        assert(details['code'] == status.HTTP_200_OK)
+        assert details["neo4jreachable"]
+        assert details["s3reachable"]
+        assert details["code"] == status.HTTP_200_OK
 
     def test_create_network(
         self, n4js_preloaded, test_client, network_tyk2, scope_test

--- a/fah_alchemy/tests/integration/interface/test_api.py
+++ b/fah_alchemy/tests/integration/interface/test_api.py
@@ -40,6 +40,10 @@ class TestAPI:
     def test_info(self, test_client):
         response = test_client.get("/info")
         assert response.status_code == 200
+    
+    def test_check(self, test_client):
+        response = test_client.get("/check")
+        assert response.status_code == 200
 
     def test_create_network(
         self, n4js_preloaded, test_client, network_tyk2, scope_test

--- a/fah_alchemy/tests/integration/storage/test_objectstore.py
+++ b/fah_alchemy/tests/integration/storage/test_objectstore.py
@@ -9,6 +9,12 @@ from fah_alchemy.storage.models import ObjectStoreRef
 
 
 class TestS3ObjectStore:
+
+    def test_delete(self, s3os: S3ObjectStore):
+        # write check
+        s3os._store_bytes('_check_test', b'test_check')
+        s3os._delete('_check_test')
+
     def test_push_protocolresult(self, s3os: S3ObjectStore, protocoldagresult):
 
         # try to push the result

--- a/fah_alchemy/tests/integration/storage/test_objectstore.py
+++ b/fah_alchemy/tests/integration/storage/test_objectstore.py
@@ -9,11 +9,10 @@ from fah_alchemy.storage.models import ObjectStoreRef
 
 
 class TestS3ObjectStore:
-
     def test_delete(self, s3os: S3ObjectStore):
         # write check
-        s3os._store_bytes('_check_test', b'test_check')
-        s3os._delete('_check_test')
+        s3os._store_bytes("_check_test", b"test_check")
+        s3os._delete("_check_test")
 
     def test_push_protocolresult(self, s3os: S3ObjectStore, protocoldagresult):
 


### PR DESCRIPTION
Fixes #55

Adds a method on `FahAlchemyClientBase` to poll endpoints on `FahAlchemyAPI` and `FahAlchemyComputeAPI` that check the status of the `ObjectStore` and `StateStore`

Notes:

I returned the status code as part of the `JSON` payload, I know this is probably not the right way to do it but wasn't exactly sure what the best way was to return both the payload and the status code.