### PR TITLE
Add docs build and deploy workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,48 @@
+name: "Docs build and deploy"
+on: [push]
+
+defaults:
+  run:
+    shell: bash -l {0}
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    env:
+      OE_LICENSE: ${{ github.workspace }}/oe_license.txt
+
+    steps:
+      - name: checkout
+      - uses: actions/checkout@v3
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+            auto-update-conda: true
+            use-mamba: true
+            python-version: ${{ matrix.python-version }}
+            miniforge-variant: Mambaforge
+            environment-file: devtools/conda-envs/test.yml
+            activate-environment: fah-alchemy-test
+
+      - name: Decrypt OpenEye license
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        env:
+          OE_LICENSE_TEXT: ${{ secrets.OE_LICENSE }}
+        run: |
+          echo "${OE_LICENSE_TEXT}" > ${OE_LICENSE}
+          python -c "import openeye; assert openeye.oechem.OEChemIsLicensed(), 'OpenEye license checks failed!'"
+
+      - name: "Install"
+        run: python setup.py develop --no-deps
+
+      - name: "Build docs"
+        run: |
+          cd docs
+          make html
+
+      - name: Deploy 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@3.7.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages # The branch the action should deploy to.
+          FOLDER: docs/_build/html # The folder the action should deploy.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,7 @@ defaults:
 
 jobs:
   build-and-deploy:
+    name: "Build and deploy docs"
     runs-on: ubuntu-latest
     env:
       OE_LICENSE: ${{ github.workspace }}/oe_license.txt

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,12 +9,18 @@ jobs:
   build-and-deploy:
     name: "Build and deploy docs"
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu']
+        python-version:
+          - 3.9
     env:
       OE_LICENSE: ${{ github.workspace }}/oe_license.txt
 
     steps:
-      - name: checkout
       - uses: actions/checkout@v3
+      
       - uses: conda-incubator/setup-miniconda@v2
         with:
             auto-update-conda: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,14 +13,8 @@ defaults:
 
 jobs:
   build-and-deploy:
-    name: "Build and deploy docs"
+    name: "Docs - build and deploy"
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ['ubuntu']
-        python-version:
-          - 3.9
     env:
       OE_LICENSE: ${{ github.workspace }}/oe_license.txt
 
@@ -31,9 +25,9 @@ jobs:
         with:
             auto-update-conda: true
             use-mamba: true
-            python-version: ${{ matrix.python-version }}
+            python-version: 3.9
             miniforge-variant: Mambaforge
-            environment-file: devtools/conda-envs/test.yml
+            environment-file: devtools/conda-envs/docs.yml
             activate-environment: fah-alchemy-test
 
       - name: Decrypt OpenEye license

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,11 @@
 name: "Docs build and deploy"
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 defaults:
   run:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
             python-version: 3.9
             miniforge-variant: Mambaforge
             environment-file: devtools/conda-envs/docs.yml
-            activate-environment: fah-alchemy-test
+            activate-environment: fah-alchemy-docs
 
       - name: Decrypt OpenEye license
         if: ${{ !github.event.pull_request.head.repo.fork }}

--- a/devtools/conda-envs/docs.yml
+++ b/devtools/conda-envs/docs.yml
@@ -1,4 +1,4 @@
-name: fah-alchemy-test
+name: fah-alchemy-docs
 channels:
   - jaimergp/label/unsupported-cudatoolkit-shim
   - conda-forge

--- a/devtools/conda-envs/docs.yml
+++ b/devtools/conda-envs/docs.yml
@@ -1,0 +1,66 @@
+name: fah-alchemy-test
+channels:
+  - jaimergp/label/unsupported-cudatoolkit-shim
+  - conda-forge
+  - openeye
+dependencies:
+  - python =3.9
+
+  # gufe dependencies
+  - numpy
+  - networkx
+  - rdkit
+  - pip
+  - pydantic
+  - openff-toolkit
+  - openff-units
+  - openeye-toolkits
+  - typing-extensions
+
+  # fah-alchemy dependencies
+  ## state store
+  - neo4j-python-driver
+  - py2neo
+  - monotonic    # needed by py2neo, but not pulled in
+  - docker-py    # for grolt
+
+  ## object store
+  - boto3        # aws s3
+
+  ## api(s)
+  - fastapi
+  - uvicorn
+  - gunicorn
+  - python-jose
+  - passlib
+  - bcrypt
+  - python-multipart
+  - starlette
+  - httpx
+  - cryptography
+
+  ## cli
+  - click
+
+  # testing
+  - pytest
+  - pytest-xdist
+  - pytest-cov
+  - coverage
+  - moto
+
+  # needed for openfe-benchmark tests
+  - lomap2>=2.1.0
+  - openmmtools
+  - openmmforcefields
+
+  # needed for docs
+  - sphinx
+
+  - pip:
+    - git+https://github.com/dotsdl/grolt@relax-cryptography # neo4j test server deployment
+    - git+https://github.com/OpenFreeEnergy/gufe@result-handling-improvements
+    - git+https://github.com/OpenFreeEnergy/openfe
+    - git+https://github.com/OpenFreeEnergy/openfe-benchmarks
+    - git+https://github.com/mikemhenry/openff-models.git@support_nested_models
+    #- git+https://github.com/openforcefield/protein-ligand-benchmark


### PR DESCRIPTION
Fixes #62 and adds docs deployment to Github Pages. This is intended as a first swipe at publishing the docs rather than a polished final product. 

 I chose github pages simply because its the easiest for me to set up having worked with it before, but as suggested by @mikemhenry, there is no vendor lock so if people would prefer RTD I am happy to use that instead. 