### PR TITLE
Add hierarchy to `Scope`

### DIFF
--- a/fah_alchemy/base/api.py
+++ b/fah_alchemy/base/api.py
@@ -36,7 +36,8 @@ from ..security.models import Token, TokenData, CredentialedEntity
 
 
 def validate_scopes(scope: Scope, token: TokenData) -> None:
-    """Verify that token data has specified Scope encoded."""
+    """Verify that token data has specified Scope encoded directly or is accessible via
+    scope hierarchy."""
 
     if not isinstance(scope, Scope):
         raise ValueError("`scope` must be a `Scope` object to ensure validity")
@@ -47,7 +48,7 @@ def validate_scopes(scope: Scope, token: TokenData) -> None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=(
-                f"Targeted scope '{scope}' not in found among scopes for this identity: {token.scopes}."
+                f"Targeted scope '{scope}' not accessible via scopes for this identity: {token.scopes}."
             ),
             headers={"WWW-Authenticate": "Bearer"},
         )

--- a/fah_alchemy/base/api.py
+++ b/fah_alchemy/base/api.py
@@ -66,10 +66,24 @@ def validate_scopes_query(
     """
 
     token_scopes = [Scope.from_str(ts) for ts in token.scopes]
-    scope_intersection = [ts for ts in token_scopes if query_scope.is_superset(ts)]
+    
+    # if query_scope is a point in scope space ("specific"), then we want to
+    # ensure that it sits within the authorized token scopes and return only it;
+    # if it doesn't, then we return an empty list
+    if query_scope.specific():
+        scope_space = ([query_scope] 
+                       if any([Scope.from_str(ts).is_superset(query_scope) for ts in token.scopes]) 
+                       else [])
+
+    # if query_scope is not specific, we want to return all (and only)
+    # authorized token scopes that fall within it
+    else:
+        scopes_space = [ts for ts in token_scopes if query_scope.is_superset(ts)]
+
+
     if as_str:
-        scope_intersection = [str(s) for s in scope_intersection]
-    return scope_intersection
+        scope_space = [str(s) for s in scope_space]
+    return scope_space
 
 
 class QueryGUFEHandler:

--- a/fah_alchemy/base/api.py
+++ b/fah_alchemy/base/api.py
@@ -79,7 +79,9 @@ def validate_scopes_query(
         ):
 
             # match (query_org == token_org) then (query_campaign == token_campaign) then (query_proj == token_proj)
-            if not (query_field == target_field or query_field is None):
+            if not (
+                query_field == target_field or query_field is None or query_field == "*"
+            ):
 
                 # if not matched, don't add
                 # don't need to continue loop, unmatched

--- a/fah_alchemy/base/api.py
+++ b/fah_alchemy/base/api.py
@@ -62,39 +62,12 @@ def validate_scopes_query(
 
     If as_str is True, returns a list of str rather than list of Scopes.
 
-    As of now, does not allow wildcard searches against lower hierarchy scope tiers as no official hierarchy is
-    supported. I.e. Organizational access does not automatically confer all Campaign access, and Campaign access
-    does not confer all Project access.
     """
 
-    # cast token to list of Scope strs
-    accessible_scopes = token.scopes
-    scope_intersection = []
-
-    # iterate through (org, camp, proj) tuple query intersecting against accessible scopes
-    for accessible_scope in accessible_scopes:
-
-        # assume we're adding it
-        acc_scope = Scope.from_str(accessible_scope)
-        add_it_in = True
-
-        for (query_field, target_field) in zip(
-            query_scope.to_tuple(), acc_scope.to_tuple()
-        ):
-
-            # match (query_org == token_org) then (query_campaign == token_campaign) then (query_proj == token_proj)
-            if not (
-                query_field == target_field or query_field is None or query_field == "*"
-            ):
-
-                # if not matched, don't add
-                # don't need to continue loop, unmatched
-                add_it_in = False
-                break
-
-        if add_it_in:
-            scope_intersection.append(acc_scope if not as_str else accessible_scope)
-
+    token_scopes = [Scope.from_str(ts) for ts in token.scopes]
+    scope_intersection = [ts for ts in token_scopes if query_scope.is_superset(ts)]
+    if as_str:
+        scope_intersection = [str(s) for s in scope_intersection]
     return scope_intersection
 
 

--- a/fah_alchemy/base/api.py
+++ b/fah_alchemy/base/api.py
@@ -74,7 +74,7 @@ def validate_scopes_query(
     # we also want to return the query_scope if it is a subset of any of the
     # authorized token scopes
     if any([Scope.from_str(ts).is_superset(query_scope) for ts in token.scopes]):
-        scope_space.add(query_scope) 
+        scope_space.add(query_scope)
 
     scope_space = list(scope_space)
 

--- a/fah_alchemy/base/api.py
+++ b/fah_alchemy/base/api.py
@@ -41,9 +41,9 @@ def validate_scopes(scope: Scope, token: TokenData) -> None:
     if not isinstance(scope, Scope):
         raise ValueError("`scope` must be a `Scope` object to ensure validity")
 
-    scope = str(scope)
-    # Check if scope among scopes accessible
-    if scope not in token.scopes:
+    scope_in_token = any([Scope.from_str(ts).is_superset(scope) for ts in token.scopes])
+
+    if not scope_in_token:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=(

--- a/fah_alchemy/base/api.py
+++ b/fah_alchemy/base/api.py
@@ -66,20 +66,21 @@ def validate_scopes_query(
     """
 
     token_scopes = [Scope.from_str(ts) for ts in token.scopes]
-    
+
     # if query_scope is a point in scope space ("specific"), then we want to
     # ensure that it sits within the authorized token scopes and return only it;
     # if it doesn't, then we return an empty list
     if query_scope.specific():
-        scope_space = ([query_scope] 
-                       if any([Scope.from_str(ts).is_superset(query_scope) for ts in token.scopes]) 
-                       else [])
+        scope_space = (
+            [query_scope]
+            if any([Scope.from_str(ts).is_superset(query_scope) for ts in token.scopes])
+            else []
+        )
 
     # if query_scope is not specific, we want to return all (and only)
     # authorized token scopes that fall within it
     else:
         scopes_space = [ts for ts in token_scopes if query_scope.is_superset(ts)]
-
 
     if as_str:
         scope_space = [str(s) for s in scope_space]

--- a/fah_alchemy/base/api.py
+++ b/fah_alchemy/base/api.py
@@ -35,8 +35,12 @@ from ..security.auth import (
 from ..security.models import Token, TokenData, CredentialedEntity
 
 
-def validate_scopes(scope: Union[Scope, str], token: TokenData) -> None:
-    """Verify that token data has specified scopes encoded"""
+def validate_scopes(scope: Scope, token: TokenData) -> None:
+    """Verify that token data has specified Scope encoded."""
+
+    if not isinstance(scope, Scope):
+        raise ValueError("`scope` must be a `Scope` object to ensure validity")
+
     scope = str(scope)
     # Check if scope among scopes accessible
     if scope not in token.scopes:
@@ -53,7 +57,7 @@ def validate_scopes_query(
     query_scope: Scope, token: TokenData, as_str: bool = False
 ) -> Union[list[Scope], list[str]]:
     """
-    Create the intersection of queried scopes and token, where query scopes may include 'all' / wildcard.
+    Create the intersection of queried scopes and token, where query scopes may include 'all' / wildcard (`None`).
     No scopes outside of those included in token will be included in scopes returned.
 
     If as_str is True, returns a list of str rather than list of Scopes.

--- a/fah_alchemy/base/api.py
+++ b/fah_alchemy/base/api.py
@@ -67,20 +67,16 @@ def validate_scopes_query(
 
     token_scopes = [Scope.from_str(ts) for ts in token.scopes]
 
-    # if query_scope is a point in scope space ("specific"), then we want to
-    # ensure that it sits within the authorized token scopes and return only it;
-    # if it doesn't, then we return an empty list
-    if query_scope.specific():
-        scope_space = (
-            [query_scope]
-            if any([Scope.from_str(ts).is_superset(query_scope) for ts in token.scopes])
-            else []
-        )
+    # we want to return all (and only) authorized token scopes that fall within
+    # the query_scope
+    scope_space = {ts for ts in token_scopes if query_scope.is_superset(ts)}
 
-    # if query_scope is not specific, we want to return all (and only)
-    # authorized token scopes that fall within it
-    else:
-        scopes_space = [ts for ts in token_scopes if query_scope.is_superset(ts)]
+    # we also want to return the query_scope if it is a subset of any of the
+    # authorized token scopes
+    if any([Scope.from_str(ts).is_superset(query_scope) for ts in token.scopes]):
+        scope_space.add(query_scope) 
+
+    scope_space = list(scope_space)
 
     if as_str:
         scope_space = [str(s) for s in scope_space]

--- a/fah_alchemy/models.py
+++ b/fah_alchemy/models.py
@@ -64,9 +64,13 @@ class Scope(BaseModel):
         org, campaign, project = (i if i != "*" else None for i in string.split("-"))
         return cls(org=org, campaign=campaign, project=project)
 
-    def is_superset(self, other) -> bool:
-        """Return True if this Scope is a superset of another. Check for a superset
-        not a proper superset so that two equal scopes also return `True`."""
+    def is_superset(self, other: Scope) -> bool:
+        """Return `True` if this Scope is a superset of another.
+
+        Check for a superset (not a proper superset) so that two equal scopes
+        also return `True`.
+
+        """
         if self.org is not None and self.org != other.org:
             return False
         if self.campaign is not None and self.campaign != other.campaign:
@@ -102,12 +106,6 @@ class ScopedKey(BaseModel):
     @validator("gufe_key")
     def cast_gufe_key(cls, v):
         return GufeKey(v)
-
-    @staticmethod
-    def _validate_component(v, component):
-        if v is not None and "-" in v:
-            raise ValueError(f"'{component}' must not contain dashes ('-')")
-        return v
 
     def __repr__(self):  # pragma: no cover
         return f"<ScopedKey('{str(self)}')>"

--- a/fah_alchemy/models.py
+++ b/fah_alchemy/models.py
@@ -125,18 +125,20 @@ class InvalidScopeError(ValueError):
 def _is_wildcard(char: Union[str, None]) -> bool:
     if char is None or char == "*":
         return True
+    else:
+        return False
 
 
 def _find_wildcard(scope_list: list) -> Union[int, None]:
     """Finds the first wildcard in a scope list."""
     for i, scope in enumerate(scope_list):
-        if scope == "*" or scope == None:
+        if _is_wildcard(scope):
             return i
     else:
         return None
 
 
-def _hierarchy_valid(scope_list: list):
+def _hierarchy_valid(scope_list: list[Union[str, None]]):
     """Checks that the scope hierarchy is valid."""
 
     if len(scope_list) != 3:

--- a/fah_alchemy/models.py
+++ b/fah_alchemy/models.py
@@ -65,7 +65,8 @@ class Scope(BaseModel):
         return cls(org=org, campaign=campaign, project=project)
 
     def is_superset(self, other) -> bool:
-        """Return True if this Scope is a superset of another."""
+        """Return True if this Scope is a superset of another. Check for a superset
+        not a proper superset so that two equal scopes also return `True`."""
         if self.org is not None and self.org != other.org:
             return False
         if self.campaign is not None and self.campaign != other.campaign:

--- a/fah_alchemy/models.py
+++ b/fah_alchemy/models.py
@@ -64,9 +64,15 @@ class Scope(BaseModel):
         org, campaign, project = (i if i != "*" else None for i in string.split("-"))
         return cls(org=org, campaign=campaign, project=project)
 
-    def superset(self, other):
+    def is_superset(self, other) -> bool:
         """Return True if this Scope is a superset of another."""
-        return NotImplementedError
+        if self.org is not None and self.org != other.org:
+            return False
+        if self.campaign is not None and self.campaign != other.campaign:
+            return False
+        if self.project is not None and self.project != other.project:
+            return False
+        return True
 
     def __repr__(self):  # pragma: no cover
         return f"<Scope('{str(self)}')>"

--- a/fah_alchemy/models.py
+++ b/fah_alchemy/models.py
@@ -30,7 +30,7 @@ class Scope(BaseModel):
     def _validate_component(v, component):
         if v is not None and "-" in v:
             raise ValueError(f"'{component}' must not contain dashes ('-')")
-        elif v == '*':
+        elif v == "*":
             return None
         return v
 
@@ -136,7 +136,7 @@ class InvalidScopeError(ValueError):
 
 
 def _is_wildcard(char: Union[str, None]) -> bool:
-    return (char is None)
+    return char is None
 
 
 def _find_wildcard(scope_list: list) -> Union[int, None]:

--- a/fah_alchemy/models.py
+++ b/fah_alchemy/models.py
@@ -144,7 +144,7 @@ def _is_wildcard(char: Union[str, None]) -> bool:
 
 
 def _find_wildcard(scope_list: list) -> Union[int, None]:
-    """Finds the first wildcard in a scope list."""
+    """Finds the index of the first wildcard in a scope list."""
     for i, scope in enumerate(scope_list):
         if _is_wildcard(scope):
             return i

--- a/fah_alchemy/models.py
+++ b/fah_alchemy/models.py
@@ -42,7 +42,11 @@ class Scope(BaseModel):
         project = values.get("project")
         scope_list = [org, campaign, project]
         if not _hierarchy_valid(scope_list):
-            raise InvalidScopeError(f"Invalid scope hierarchy: {values}")
+            raise InvalidScopeError(
+                f"Invalid scope hierarchy: {values}, cannot specify wildcard ('*')"
+                " in a scope component if a less specific scope component is not"
+                " given, unless all components are wildcards (*-*-*)"
+            )
         return values
 
     class Config:

--- a/fah_alchemy/models.py
+++ b/fah_alchemy/models.py
@@ -4,7 +4,7 @@ Data models --- :mod:`fah-alchemy.models`
 
 """
 from typing import Optional, Union
-from pydantic import BaseModel, Field, validator, root_validator, ValidationError
+from pydantic import BaseModel, Field, validator, root_validator
 from gufe.tokenization import GufeKey
 
 
@@ -64,8 +64,8 @@ class Scope(BaseModel):
         org, campaign, project = (i if i != "*" else None for i in string.split("-"))
         return cls(org=org, campaign=campaign, project=project)
 
-    def overlap(self, other):
-        """Return True if this Scope overlaps with another"""
+    def superset(self, other):
+        """Return True if this Scope is a superset of another."""
         return NotImplementedError
 
     def __repr__(self):  # pragma: no cover

--- a/fah_alchemy/models.py
+++ b/fah_alchemy/models.py
@@ -64,7 +64,7 @@ class Scope(BaseModel):
         org, campaign, project = (i if i != "*" else None for i in string.split("-"))
         return cls(org=org, campaign=campaign, project=project)
 
-    def is_superset(self, other: Scope) -> bool:
+    def is_superset(self, other: "Scope") -> bool:
         """Return `True` if this Scope is a superset of another.
 
         Check for a superset (not a proper superset) so that two equal scopes

--- a/fah_alchemy/tests/unit/test_base_api.py
+++ b/fah_alchemy/tests/unit/test_base_api.py
@@ -86,16 +86,16 @@ def test_validate_scopes_invalid(tokendata, scope_str):
         ("org2-*-*", ["org2-*-*"]),
         ("org3-campaignA-*", ["org3-campaignA-*"]),
         ("org1-campaignB-projectIII", []),
-        ("org2-campaignC-*", []),
+        ("org2-campaignC-*", ['org2-campaignC-*']),
         ("org4-*-*", []),
     ],
 )
 def test_validate_scopes_query(tokendata, scope_str, expected):
     expected_scopes = [Scope.from_str(s) for s in expected]
     assert (
-        validate_scopes_query(Scope.from_str(scope_str), tokendata) == expected_scopes
+        set(validate_scopes_query(Scope.from_str(scope_str), tokendata)) == set(expected_scopes)
     )
     assert (
-        validate_scopes_query(Scope.from_str(scope_str), tokendata, as_str=True)
-        == expected
+        set(validate_scopes_query(Scope.from_str(scope_str), tokendata, as_str=True))
+        == set(expected)
     )

--- a/fah_alchemy/tests/unit/test_base_api.py
+++ b/fah_alchemy/tests/unit/test_base_api.py
@@ -4,7 +4,7 @@ from fastapi import HTTPException
 from pydantic import ValidationError
 
 from fah_alchemy.base.api import validate_scopes, validate_scopes_query
-from fah_alchemy.models import Scope, ScopedKey, InvalidScopeError
+from fah_alchemy.models import Scope, ScopedKey
 from fah_alchemy.security.models import Token, TokenData, CredentialedEntity
 
 
@@ -26,6 +26,8 @@ def tokendata():
             "org1-campaignA-projectI",
             "org1-campaignB-projectI",
             "org1-campaignB-projectII",
+            "org2-*-*",
+            "org3-campaignA-*",
         ],
     )
 
@@ -77,19 +79,3 @@ def test_validate_scopes_query(tokendata):
 
     assert len(matches) == 3
     assert matches == tokendata.scopes
-
-
-@pytest.mark.parametrize(
-    "scope_string", ["*-*-*", "org1-*-*", "org1-campaignA-*", "org1-campaignA-projectI"]
-)
-def test_wildcard_scopes_valid(scope_string):
-    scope = Scope.from_str(scope_string)
-
-
-@pytest.mark.parametrize(
-    "scope_string",
-    ["*-*-projectI", "*-campaignA-*", "*-campaignA-projectI", "org1-*-projectI"],
-)
-def test_wildcard_scopes_invalid(scope_string):
-    with pytest.raises(ValidationError):
-        scope = Scope.from_str(scope_string)

--- a/fah_alchemy/tests/unit/test_base_api.py
+++ b/fah_alchemy/tests/unit/test_base_api.py
@@ -53,16 +53,16 @@ def test_validate_scopes_query(tokendata):
 
 
 @pytest.mark.parametrize(
-    "scope_tokens", ["*-*-*", "org1-*-*", "org1-campaignA-*", "org1-campaignA-projectI"]
+    "scope_string", ["*-*-*", "org1-*-*", "org1-campaignA-*", "org1-campaignA-projectI"]
 )
-def test_wildcard_scopes_valid(scope_tokens):
-    scope = Scope.from_str(scope_tokens)
+def test_wildcard_scopes_valid(scope_string):
+    scope = Scope.from_str(scope_string)
 
 
 @pytest.mark.parametrize(
-    "scope_tokens",
+    "scope_string",
     ["*-*-projectI", "*-campaignA-*", "*-campaignA-projectI", "org1-*-projectI"],
 )
-def test_wildcard_scopes_invalid(scope_tokens):
+def test_wildcard_scopes_invalid(scope_string):
     with pytest.raises(ValidationError):
-        scope = Scope.from_str(scope_tokens)
+        scope = Scope.from_str(scope_string)

--- a/fah_alchemy/tests/unit/test_base_api.py
+++ b/fah_alchemy/tests/unit/test_base_api.py
@@ -86,16 +86,15 @@ def test_validate_scopes_invalid(tokendata, scope_str):
         ("org2-*-*", ["org2-*-*"]),
         ("org3-campaignA-*", ["org3-campaignA-*"]),
         ("org1-campaignB-projectIII", []),
-        ("org2-campaignC-*", ['org2-campaignC-*']),
+        ("org2-campaignC-*", ["org2-campaignC-*"]),
         ("org4-*-*", []),
     ],
 )
 def test_validate_scopes_query(tokendata, scope_str, expected):
     expected_scopes = [Scope.from_str(s) for s in expected]
-    assert (
-        set(validate_scopes_query(Scope.from_str(scope_str), tokendata)) == set(expected_scopes)
+    assert set(validate_scopes_query(Scope.from_str(scope_str), tokendata)) == set(
+        expected_scopes
     )
-    assert (
-        set(validate_scopes_query(Scope.from_str(scope_str), tokendata, as_str=True))
-        == set(expected)
-    )
+    assert set(
+        validate_scopes_query(Scope.from_str(scope_str), tokendata, as_str=True)
+    ) == set(expected)

--- a/fah_alchemy/tests/unit/test_base_api.py
+++ b/fah_alchemy/tests/unit/test_base_api.py
@@ -32,13 +32,31 @@ def tokendata():
     )
 
 
-def test_validate_scopes(tokendata):
-    assert validate_scopes(Scope("org1", "campaignB", "projectI"), tokendata) is None
-    assert validate_scopes(Scope("org1", "campaignA", "projectI"), tokendata) is None
-    assert validate_scopes(Scope("org1", "campaignB", "projectII"), tokendata) is None
+@pytest.mark.parametrize(
+    "scope_str",
+    [
+        "org1-campaignA-projectI",
+        "org1-campaignB-projectI",
+        "org1-campaignB-projectII",
+        "org2-campaignB-projectII",
+        "org3-campaignA-projectII",
+    ],
+)
+def test_validate_scopes_valid(tokendata, scope_str):
+    assert validate_scopes(Scope.from_str(scope_str), tokendata) is None
 
+
+@pytest.mark.parametrize(
+    "scope_str",
+    [
+        "org4-campaignB-projectII",
+        "org3-campaignB-projectII",
+        "org1-campaignB-projectIII",
+    ],
+)
+def test_validate_scopes_invalid(tokendata, scope_str):
     with pytest.raises(HTTPException):
-        validate_scopes(Scope("org2", "campaignB", "projectII"), tokendata) is None
+        validate_scopes(Scope.from_str(scope_str), tokendata)
 
 
 def test_validate_scopes_query(tokendata):

--- a/fah_alchemy/tests/unit/test_base_api.py
+++ b/fah_alchemy/tests/unit/test_base_api.py
@@ -51,12 +51,29 @@ def test_validate_scopes_query(tokendata):
     assert len(matches) == 2
     assert matches == tokendata.scopes[1:]
 
+    matches = validate_scopes_query(
+        Scope("org1", "campaignB", "*"), tokendata, as_str=True
+    )
+
+    assert len(matches) == 2
+    assert matches == tokendata.scopes[1:]
+
     matches = validate_scopes_query(Scope("org1", None, None), tokendata, as_str=True)
 
     assert len(matches) == 3
     assert matches == tokendata.scopes
 
+    matches = validate_scopes_query(Scope("org1", "*", "*"), tokendata, as_str=True)
+
+    assert len(matches) == 3
+    assert matches == tokendata.scopes
+
     matches = validate_scopes_query(Scope(), tokendata, as_str=True)
+
+    assert len(matches) == 3
+    assert matches == tokendata.scopes
+
+    matches = validate_scopes_query(Scope("*", "*", "*"), tokendata, as_str=True)
 
     assert len(matches) == 3
     assert matches == tokendata.scopes

--- a/fah_alchemy/tests/unit/test_base_api.py
+++ b/fah_alchemy/tests/unit/test_base_api.py
@@ -4,8 +4,18 @@ from fastapi import HTTPException
 from pydantic import ValidationError
 
 from fah_alchemy.base.api import validate_scopes, validate_scopes_query
-from fah_alchemy.models import Scope, InvalidScopeError
+from fah_alchemy.models import Scope, ScopedKey, InvalidScopeError
 from fah_alchemy.security.models import Token, TokenData, CredentialedEntity
+
+
+@pytest.mark.parametrize(
+    "scope", (("a-", "a", "a"), ("a", "a-", "a"), ("a", "a", "a-"))
+)
+@pytest.mark.parametrize("scope_cls", [Scope, ScopedKey])
+def test_create_invalid_scope_with_dash(scope_cls, scope):
+    org, campaign, project = scope
+    with pytest.raises(ValidationError):
+        scope_cls(org=org, campaign=campaign, project=project)
 
 
 @pytest.fixture

--- a/fah_alchemy/tests/unit/test_models.py
+++ b/fah_alchemy/tests/unit/test_models.py
@@ -1,0 +1,21 @@
+import pytest
+
+from pydantic import ValidationError
+
+from fah_alchemy.models import Scope
+
+
+@pytest.mark.parametrize(
+    "scope_string", ["*-*-*", "org1-*-*", "org1-campaignA-*", "org1-campaignA-projectI"]
+)
+def test_wildcard_scopes_valid(scope_string):
+    scope = Scope.from_str(scope_string)
+
+
+@pytest.mark.parametrize(
+    "scope_string",
+    ["*-*-projectI", "*-campaignA-*", "*-campaignA-projectI", "org1-*-projectI"],
+)
+def test_wildcard_scopes_invalid(scope_string):
+    with pytest.raises(ValidationError):
+        scope = Scope.from_str(scope_string)

--- a/fah_alchemy/tests/unit/test_models.py
+++ b/fah_alchemy/tests/unit/test_models.py
@@ -43,7 +43,7 @@ def test_scope_superset_true(super_scope_str, sub_scope_str):
 
 
 @pytest.mark.parametrize(
-    # test the inverse of test_scope_superset_true() and also cases where 
+    # test the inverse of test_scope_superset_true() and also cases where
     # the scopes have the same level but not the same value
     "sub_scope_str, super_scope_str",
     [

--- a/fah_alchemy/tests/unit/test_models.py
+++ b/fah_alchemy/tests/unit/test_models.py
@@ -22,15 +22,44 @@ def test_wildcard_scopes_invalid(scope_string):
 
 
 @pytest.mark.parametrize(
-    "scope_string1, scope_string2",
+    "super_scope_str, sub_scope_str",
     [
+        ("*-*-*", "*-*-*"),
         ("*-*-*", "org1-*-*"),
-        ("org1-*-*", "org1-campaignA-*"),
-        ("org1-campaignA-*", "org1-campaignA-projectI"),
+        ("*-*-*", "org1-campaignA-*"),
         ("*-*-*", "org1-campaignA-projectI"),
+        ("org1-*-*", "org1-*-*"),
+        ("org1-*-*", "org1-campaignA-*"),
+        ("org1-*-*", "org1-campaignA-projectI"),
+        ("org1-campaignA-*", "org1-campaignA-*"),
+        ("org1-campaignA-*", "org1-campaignA-projectI"),
+        ("org1-campaignA-projectI", "org1-campaignA-projectI"),
     ],
 )
-def test_scope_superset_true(scope_string1, scope_string2):
-    scope1 = Scope.from_str(scope_string1)
-    scope2 = Scope.from_str(scope_string2)
-    assert scope1.is_superset(scope2)
+def test_scope_superset_true(super_scope_str, sub_scope_str):
+    super_scope = Scope.from_str(super_scope_str)
+    sub_scope = Scope.from_str(sub_scope_str)
+    assert super_scope.is_superset(sub_scope)
+
+
+@pytest.mark.parametrize(
+    "sub_scope_str, super_scope_str",
+    [
+        ("*-*-*", "org1-*-*"),
+        ("*-*-*", "org1-campaignA-*"),
+        ("*-*-*", "org1-campaignA-projectI"),
+        ("org1-*-*", "org1-campaignA-*"),
+        ("org1-*-*", "org1-campaignA-projectI"),
+        ("org1-campaignA-projectI", "org1-campaignA-projectII"),
+        ("org1-campaignB-projectI", "org1-campaignA-projectI"),
+        ("org2-campaignB-projectI", "org1-campaignA-projectI"),
+        ("org1-campaignB-projectI", "org1-campaignA-*"),
+        ("org1-campaignB-*", "org1-campaignA-*"),
+        ("org1-campaignA-*", "org2-*-*"),
+        ("org1-campaignA-projectI", "org2-*-*"),
+    ],
+)
+def test_scope_superset_false(super_scope_str, sub_scope_str):
+    super_scope = Scope.from_str(super_scope_str)
+    sub_scope = Scope.from_str(sub_scope_str)
+    assert not super_scope.is_superset(sub_scope)

--- a/fah_alchemy/tests/unit/test_models.py
+++ b/fah_alchemy/tests/unit/test_models.py
@@ -19,3 +19,18 @@ def test_wildcard_scopes_valid(scope_string):
 def test_wildcard_scopes_invalid(scope_string):
     with pytest.raises(ValidationError):
         scope = Scope.from_str(scope_string)
+
+
+@pytest.mark.parametrize(
+    "scope_string1, scope_string2",
+    [
+        ("*-*-*", "org1-*-*"),
+        ("org1-*-*", "org1-campaignA-*"),
+        ("org1-campaignA-*", "org1-campaignA-projectI"),
+        ("*-*-*", "org1-campaignA-projectI"),
+    ],
+)
+def test_scope_superset_true(scope_string1, scope_string2):
+    scope1 = Scope.from_str(scope_string1)
+    scope2 = Scope.from_str(scope_string2)
+    assert scope1.is_superset(scope2)

--- a/fah_alchemy/tests/unit/test_models.py
+++ b/fah_alchemy/tests/unit/test_models.py
@@ -43,6 +43,8 @@ def test_scope_superset_true(super_scope_str, sub_scope_str):
 
 
 @pytest.mark.parametrize(
+    # test the inverse of test_scope_superset_true() and also cases where 
+    # the scopes have the same level but not the same value
     "sub_scope_str, super_scope_str",
     [
         ("*-*-*", "org1-*-*"),
@@ -56,6 +58,7 @@ def test_scope_superset_true(super_scope_str, sub_scope_str):
         ("org1-campaignB-projectI", "org1-campaignA-*"),
         ("org1-campaignB-*", "org1-campaignA-*"),
         ("org1-campaignA-*", "org2-*-*"),
+        ("org1-*-*", "org2-*-*"),
         ("org1-campaignA-projectI", "org2-*-*"),
     ],
 )


### PR DESCRIPTION
Partially fixes #42 

I have also added the `no-dash` validation for `ScopedKey`, as mentioned briefly in #42. Let me know if this is wrong and I can take it out. 

I also added a test for invalid scope creation with a dash in the name

I have also added support for "*" wildcards in addition to `None`